### PR TITLE
Updates user guide page and index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Operations Engineering User Guides
+# Operations Engineering User Guide
 
 This repository holds the website and user guides for services and tools provided by the Operations Engineering team [Operations Engineering
-user guides](https://user-guides.operations-engineering.service.justice.gov.uk/#operations-engineering-user-guides)
+user guides](https://user-guides.operations-engineering.service.justice.gov.uk/#operations-engineering-user-guide)
 
 This repository utilises the Ministry of Justice's [template-documentation-site](https://github.com/ministryofjustice/template-documentation-site).
 
->Want to give feedback on the documentation? [Open an issue on this repository](https://github.com/ministryofjustice/operations-engineering-user-guides/issues).
+>Want to give feedback on the documentation? [Open an issue on this repository](https://github.com/ministryofjustice/operations-engineering-user-guide/issues).
 
 ## Running locally
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ user guides](https://user-guides.operations-engineering.service.justice.gov.uk/#
 
 This repository utilises the Ministry of Justice's [template-documentation-site](https://github.com/ministryofjustice/template-documentation-site).
 
->Want to give feedback on the documentation? [Open an issue on this repository](https://github.com/ministryofjustice/operations-engineering-user-guide/issues).
+> Want to give feedback on the documentation? [Open an issue on this repository](https://github.com/ministryofjustice/operations-engineering-user-guide/issues).
 
 ## Running locally
 

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -5,12 +5,12 @@ host: https://user-guides.operations-engineering.service.justice.gov.uk
 
 # Header-related options
 show_govuk_logo: false
-service_name: Operations Engineering User Guides
+service_name: Operations Engineering User Guide
 service_link: /
 
 # Links to show on right-hand-side of header
 header_links:
-  GitHub: https://github.com/ministryofjustice/operations-engineering-user-guides
+  GitHub: https://github.com/ministryofjustice/operations-engineering-user-guide
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.
 enable_search: true
@@ -30,5 +30,5 @@ max_toc_heading_level: 3
 prevent_indexing: true
 
 show_contribution_banner: true
-github_repo: ministryofjustice/operations-engineering-user-guides
+github_repo: ministryofjustice/operations-engineering-user-guide
 github_branch: main

--- a/source/documentation/information/our-alliance.html.md.erb
+++ b/source/documentation/information/our-alliance.html.md.erb
@@ -11,22 +11,22 @@ As a team, we regularly discuss and decide on our alliance, and document these o
 
 Our alliance is as follows (in alphabetical order):
 
-    We agree that there are no stupid question
-    We aim to automate
-    We appreciate work takes time
-    We are respectful of others time
-    We communicate out loud and in the open about what we are working on in our team Slack channel (#operations-engineering-team)
-    We encourage and take time to learn new stuff
-    We ensure everyone is aware of any risks/blockers
-    We have a no blame culture
-    We have fun and don’t take ourselves too seriously
-    We help each other out
-    We highlight team successes
-    We keep tickets up to date
-    We put team member wellbeing first
-    We take joint ownership of the work that we do
-    We work remote first
-    We work in a transparent way
-    We are aware of our long term goals
-    We promote internal knowledge sharing
-    We ensure high quality standards in our work
+- We agree that there are no stupid question
+- We aim to automate
+- We appreciate work takes time
+- We are respectful of others time
+- We communicate out loud and in the open about what we are working on in our team Slack channel (#operations-engineering-team)
+- We encourage and take time to learn new stuff
+- We ensure everyone is aware of any risks/blockers
+- We have a no blame culture
+- We have fun and don’t take ourselves too seriously
+- We help each other out
+- We highlight team successes
+- We keep tickets up to date
+- We put team member wellbeing first
+- We take joint ownership of the work that we do
+- We work remote first
+- We work in a transparent way
+- We are aware of our long term goals
+- We promote internal knowledge sharing
+- We ensure high quality standards in our work

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,11 +1,11 @@
 ---
 owner_slack: "#operations-engineering-alerts"
-title: MoJ Operations Engineering User Guides
+title: MoJ Operations Engineering User Guide
 last_reviewed_on: 2023-08-02
 review_in: 6 months
 ---
 
-# MoJ Operations Engineering User Guides
+# MoJ Operations Engineering User Guide
 
 These guides provide information and details about the services that Operations Engineering support.
 


### PR DESCRIPTION
This PR adds some updates:

- corrected the layout of the alliance page
- amended the site name to Operations Engineering User Guide (drops the 's')
- updates the index