### PR TITLE
Adds info to user guide

### DIFF
--- a/source/documentation/information/we-dont-do-that.html.erb.md
+++ b/source/documentation/information/we-dont-do-that.html.erb.md
@@ -7,7 +7,7 @@ review_in: 3 months
 
 # Services We Don't Manage
 
-This is a list (not comprehensive) of common requests we recieve for services that are not supported by Operations Engineering.  Please contact the teams listed below if you need help with any of the following:
+This is a list (not comprehensive) of common requests we recieve for services that are not supported by Operations Engineering. Please contact the teams listed below if you need help with any of the following:
 
 ## Analytical Platform related requests
 

--- a/source/documentation/information/we-dont-do-that.html.erb.md
+++ b/source/documentation/information/we-dont-do-that.html.erb.md
@@ -1,0 +1,74 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Services We Don't Manage
+last_reviewed_on: 2023-09-05
+review_in: 3 months
+---
+
+# Services We Don't Manage
+
+This is a list (not comprehensive) of common requests we recieve for services that are not supported by Operations Engineering.  Please contact the teams listed below if you need help with any of the following:
+
+## Analytical Platform related requests
+
+Please raise a new issue here [Data-Platform-Support](https://github.com/ministryofjustice/data-platform-support/issues/new/choose)
+
+## BrowserStack
+
+Please contact #digital_it_forum slack channel
+
+## Cloud Platform related requests
+
+Please contact #ask-cloud-platform slack channel
+
+## Confluence
+
+Please contact #digital_it_forum slack channel
+
+## Dynamic Host Configuration Protocol (DHCP)
+
+Please contact #network-operations or #ask-nvvs-devops slack channel
+
+## Figma
+
+Please contact #digital_it_forum slack channel
+
+## GSuite or other Google Apps/Features
+
+Please contact #digital_it_forum slack channel
+
+## JIRA
+
+Please contact #digital_it_forum slack channel
+
+## LucidChart
+
+Please contact #digital_it_forum slack channel
+
+## Modernisation Platform related requests
+
+Please contact #ask-modernisation-platform slack channel
+
+## MS Teams
+
+Please contact #digital_it_forum slack channel
+
+## Ordering IT Equipment
+
+Please contact #digital_it_forum slack channel
+
+## Sharepoint
+
+Please contact #digital_it_forum slack channel
+
+## Slack
+
+Please contact #digital_it_forum slack channel
+
+## Trello
+
+Please contact #digital_it_forum slack channel
+
+## VPN questions
+
+Please contact #digital_it_forum slack channel

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -9,12 +9,15 @@ review_in: 6 months
 
 These guides provide information and details about the services that Operations Engineering support.
 
+Please check [Not Supported by Operations Engineering](documentation/information/we-dont-do-that.html) for contact information for services we do not support.
+
 ## Overview
 
 * [Who are Operations Engineering?](documentation/information/operations-engineering.html)
 * [MoJ GitHub Enterprise Management](documentation/information/mojgithubenterprise.html)
 * [Our Alliance](documentation/information/our-alliance.html)
 * [How to contact Operations Engineering](documentation/information/contact.html)
+* [Not Supported by Operations Engineering](documentation/information/we-dont-do-that.html)
 
 ## What we support
 


### PR DESCRIPTION
This PR adds information and slack contact channels for services we do not support to the user guide:

- adds Not Supported by Operations Engineering page
- updates index.html to provide information to the user