### PR TITLE
Adds new content to user guide

### DIFF
--- a/source/documentation/information/githubcommunity.html.md.erb
+++ b/source/documentation/information/githubcommunity.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: GitHub Community Slack Channel
-last_reviewed_on: 2023-08-02
+last_reviewed_on: 2023-09-22
 review_in: 6 months
 ---
 
@@ -41,4 +41,4 @@ We only ask that requests related to access are kept to the [#ask-operations-eng
 
 ## Making Feature Requests to GitHub
 
-We encourage developers and analysts to suggest improvements and new features to GitHub. Please visit the [Making Feature Requests to GitHub Guide](https://operations-engineering.service.justice.gov.uk/documentation/services/github-feature-request.html) for detailed instructions on how to submit your feature request and track its progress.
+We encourage developers and analysts to suggest improvements and new features to GitHub. Please visit the [GitHub Feature Requests](information/githubfeature.html) for detailed instructions on how to submit your feature request and track its progress.

--- a/source/documentation/information/githubfeature.html.md.erb
+++ b/source/documentation/information/githubfeature.html.md.erb
@@ -1,13 +1,11 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: GitHub Feature Requests
-last_reviewed_on: 2023-08-02
+last_reviewed_on: 2023-09-22
 review_in: 6 months
 ---
 
 # GitHub Feature Requests
-
-# Making Feature Requests to GitHub
 
 At the Ministry of Justice, we encourage developers and analysts to suggest improvements and new features that could enhance their experience with GitHub. Here's how you can submit a feature request:
 

--- a/source/documentation/services/1password.html.md.erb
+++ b/source/documentation/services/1password.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: 1Password
-last_reviewed_on: 2023-08-21
+last_reviewed_on: 2023-09-21
 review_in: 6 months
 ---
 
@@ -15,7 +15,7 @@ Please refer to the [MoJ Security Guidance - 1Password](https://security-guidanc
 
 ## Request Access
 
-Contact the Operations Engineering Team via our Slack Channel, `#ask-operations-engineering`, or email [Operations Engineering](mailto:operations-engineering@digital.justice.gov.uk) to request access.
+Contact the Operations Engineering Team via our Slack Channel, `[#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4)`, or email [Operations Engineering](mailto:operations-engineering@digital.justice.gov.uk) to request access.
 
 Please include in your message:
 

--- a/source/documentation/services/github.html.md.erb
+++ b/source/documentation/services/github.html.md.erb
@@ -1,18 +1,29 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: GitHub
-last_reviewed_on: 2023-08-02
+last_reviewed_on: 2023-09-22
 review_in: 6 months
 ---
 
 # GitHub
 
-## Requesting Access
+Operations Engineering manage the GitHub Enterprise for MoJ and provide the following support:
+
+ * Access Management - requests for access to the Organisations
+ * Third-Party Collaborator Management - requests to add external 3rd party developers
+ * Team Management - we can manage teams that lack maintainers
+ * Third-Party Application and Integration Approval - review and approve requests to integrate 3rd party apps
+ * Fine-Grained Personal Access Token Requests - approval of these requests
+
+ Please contact Operations Engineering via our Slack channel [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4) for any of these requests.
+
+ For general questions, advice and information please ask in the GitHub Community Slack channel [#github-community](https://mojdt.slack.com/archives/C05L0KBA7RS)
 
 ## Information
 
 * [Github Community Slack Channel](../information/githubcommunity.html)
 * [GitHub Feature Requests](../information/githubfeature.html)
+* [MoJ GitHub Enterprise Management](../information/mojgithubenterprise.html)
 * [MoJ Repository Standards](../information/mojrepostandards.html)
 * [MoJ Repository Template](../information/mojrepotemplate.html)
 * [Storing Code in Private Repositories](../information/storing-code-in-private.html)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -49,4 +49,10 @@ Please check [Not Supported by Operations Engineering](documentation/information
 * [Storing Code in Private Repositories](documentation/information/storing-code-in-private.html)
 * [Storing Code in Public Repositories](documentation/information/storing-code-in-public.html)
 
-## Help and Support
+## Organisation Overview
+
+Below is a diagram detailing where Operation Engineering sits under Platforms and Architecture along with the other key teams and their main responsibilities.
+
+For a more detailed view that includes links to important resources, please navigate to this [interactive organisation diagram](https://app.diagrams.net/#G1eYCm5PqpsQXKQdT_XhNi-wbH4976t9M5).
+
+![Organisation Chart](images/organisation-chart.png)


### PR DESCRIPTION
This PR adds new content and updates to the user guide:

- added GitHub page
- update 1Password with slack channel link
- updates some links to point at this site instead of ops eng
- updates index with the organisational overview