### PR TITLE
:sparkles: Port over documentation from the runbooks site

### DIFF
--- a/source/documentation/information/add-repo-badge.html.md.erb
+++ b/source/documentation/information/add-repo-badge.html.md.erb
@@ -1,0 +1,42 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Add a Ministry of Justice Compliance Badge to Your Repository
+last_reviewed_on: 2023-10-20
+review_in: 3 months
+---
+
+# Add a Ministry of Justice Compliance Badge to Your Repository
+
+## Introduction
+
+The operations engineering team has created a dynamic compliance badge that you can add to your repository's README file. This badge indicates whether a repository meets the Ministry of Justice's [GitHub Repository Standards](https://operations-engineering.service.justice.gov.uk/documentation/services/repository-standards.html).
+
+We're leveraging img.shields.io, a service that provides dynamically generated badge images, to show the compliance status of your repository. When added to a repository, the badge queries our report system to obtain the repository's compliance status. If your repository is compliant, a pleasingly blue "MoJ Compliant" badge will show up on your landing page. If your repository is not compliant, a red "MoJ Non-Compliant" badge will show up instead.
+
+Please note that this badge only works with public repositories and is not compatible with private or internal ones.
+
+For a visual representation of the badge, refer to the discussion in the [operations-engineering](https://github.com/ministryofjustice/operations-engineering/discussions/717) team.
+
+## Badge Code
+
+To add the badge to your repository, include the following code in your README file:
+
+`[![repo standards badge](https://img.shields.io/endpoint?labelColor=231f20&color=005ea5&style=for-the-badge&label=MoJ%20Compliant&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fendpoint%2FREPO-NAME&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAABmJLR0QA/wD/AP+gvaeTAAAHJElEQVRYhe2YeYyW1RWHnzuMCzCIglBQlhSV2gICKlHiUhVBEAsxGqmVxCUUIV1i61YxadEoal1SWttUaKJNWrQUsRRc6tLGNlCXWGyoUkCJ4uCCSCOiwlTm6R/nfPjyMeDY8lfjSSZz3/fee87vnnPu75z3g8/kM2mfqMPVH6mf35t6G/ZgcJ/836Gdug4FjgO67UFn70+FDmjcw9xZaiegWX29lLLmE3QV4Glg8x7WbFfHlFIebS/ANj2oDgX+CXwA9AMubmPNvuqX1SnqKGAT0BFoVE9UL1RH7nSCUjYAL6rntBdg2Q3AgcAo4HDgXeBAoC+wrZQyWS3AWcDSUsomtSswEtgXaAGWlVI2q32BI0spj9XpPww4EVic88vaC7iq5Hz1BvVf6v3qe+rb6ji1p3pWrmtQG9VD1Jn5br+Knmm70T9MfUh9JaPQZu7uLsR9gEsJb3QF9gOagO7AuUTom1LpCcAkoCcwQj0VmJregzaipA4GphNe7w/MBearB7QLYCmlGdiWSm4CfplTHwBDgPHAFmB+Ah8N9AE6EGkxHLhaHU2kRhXc+cByYCqROs05NQq4oR7Lnm5xE9AL+GYC2gZ0Jmjk8VLKO+pE4HvAyYRnOwOH5N7NhMd/WKf3beApYBWwAdgHuCLn+tatbRtgJv1awhtd838LEeq30/A7wN+AwcBt+bwpD9AdOAkYVkpZXtVdSnlc7QI8BlwOXFmZ3oXkdxfidwmPrQXeA+4GuuT08QSdALxC3OYNhBe/TtzON4EziZBXD36o+q082BxgQuqvyYL6wtBY2TyEyJ2DgAXAzcC1+Xxw3RlGqiuJ6vE6QS9VGZ/7H02DDwAvELTyMDAxbfQBvggMAAYR9LR9J2cluH7AmnzuBowFFhLJ/wi7yiJgGXBLPq8A7idy9kPgvAQPcC9wERHSVcDtCfYj4E7gr8BRqWMjcXmeB+4tpbyG2kG9Sl2tPqF2Uick8B+7szyfvDhR3Z7vvq/2yqpynnqNeoY6v7LvevUU9QN1fZ3OTeppWZmeyzRoVu+rhbaHOledmoQ7LRd3SzBVeUo9Wf1DPs9X90/jX8m/e9Rn1Mnqi7nuXXW5+rK6oU7n64mjszovxyvVh9WeDcTVnl5KmQNcCMwvpbQA1xE8VZXhwDXAz4FWIkfnAlcBAwl6+SjD2wTcmPtagZnAEuA3dTp7qyNKKe8DW9UeBCeuBsbsWKVOUPvn+MRKCLeq16lXqLPVFvXb6r25dlaGdUx6cITaJ8fnpo5WI4Wuzcjcqn5Y8eI/1F+n3XvUA1N3v4ZamIEtpZRX1Y6Z/DUK2g84GrgHuDqTehpBCYend94jbnJ34DDgNGArQT9bict3Y3p1ZCnlSoLQb0sbgwjCXpY2blc7llLW1UAMI3o5CD4bmuOlwHaC6xakgZ4Z+ibgSxnOgcAI4uavI27jEII7909dL5VSrimlPKgeQ6TJCZVQjwaOLaW8BfyWbPEa1SaiTH1VfSENd85NDxHt1plA71LKRvX4BDaAKFlTgLeALtliDUqPrSV6SQCBlypgFlbmIIrCDcAl6nPAawmYhlLKFuB6IrkXAadUNj6TXlhDcCNEB/Jn4FcE0f4UWEl0NyWNvZxGTs89z6ZnatIIrCdqcCtRJmcCPwCeSN3N1Iu6T4VaFhm9n+riypouBnepLsk9p6p35fzwvDSX5eVQvaDOzjnqzTl+1KC53+XzLINHd65O6lD1DnWbepPBhQ3q2jQyW+2oDkkAtdt5udpb7W+Q/OFGA7ol1zxu1tc8zNHqXercfDfQIOZm9fR815Cpt5PnVqsr1F51wI9QnzU63xZ1o/rdPPmt6enV6sXqHPVqdXOCe1rtrg5W7zNI+m712Ir+cer4POiqfHeJSVe1Raemwnm7xD3mD1E/Z3wIjcsTdlZnqO8bFeNB9c30zgVG2euYa69QJ+9G90lG+99bfdIoo5PU4w362xHePxl1slMab6tV72KUxDvzlAMT8G0ZohXq39VX1bNzzxij9K1Qb9lhdGe931B/kR6/zCwY9YvuytCsMlj+gbr5SemhqkyuzE8xau4MP865JvWNuj0b1YuqDkgvH2GkURfakly01Cg7Cw0+qyXxkjojq9Lw+vT2AUY+DlF/otYq1Ixc35re2V7R8aTRg2KUv7+ou3x/14PsUBn3NG51S0XpG0Z9PcOPKWSS0SKNUo9Rv2Mmt/G5WpPF6pHGra7Jv410OVsdaz217AbkAPX3ubkm240belCuudT4Rp5p/DyC2lf9mfq1iq5eFe8/lu+K0YrVp0uret4nAkwlB6vzjI/1PxrlrTp/oNHbzTJI92T1qAT+BfW49MhMg6JUp7ehY5a6Tl2jjmVvitF9fxo5Yq8CaAfAkzLMnySt6uz/1k6bPx59CpCNxGfoSKA30IPoH7cQXdArwCOllFX/i53P5P9a/gNkKpsCMFRuFAAAAABJRU5ErkJggg==)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/REPO-NAME)`
+
+_note: If copying and pasting the markdown above, please replace `REPO-NAME` with the name of your repository._
+
+## Decoding the Badge Code
+
+The badge code, in a broader sense, looks like this:
+
+`[![hover-text](badge-code)](OPERATIONS-ENGINEERING-REPORT-URL#REPO-NAME "Link to report")`
+
+You can dissect the badge code into the following segments:
+
+`https://img.shields.io/badge/dynamic/json ?color=blue &style=for-the-badge &label=MoJ-Compliant &url=QUERY-URL &logo=path-to-moj-crest`
+
+Here, the `QUERY-URL` refers to the path leading to the web app API and the repository name that helps fetch a JSON result. For instance, `https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/api/v2/compliant-repository/operations-engineering-reports`.
+
+The `OPERATIONS-ENGINEERING-REPORT-URL` is `https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-github-repositories.html`.
+
+To gain a more detailed understanding of each section above or to make modifications, visit the [shields.io](https://shields.io) page.

--- a/source/documentation/information/managing-github-notifications.html.erb.md
+++ b/source/documentation/information/managing-github-notifications.html.erb.md
@@ -1,0 +1,70 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Managing GitHub Notifications
+last_reviewed_on: 2023-08-31
+review_in: 3 months
+---
+
+# User Guide: Managing GitHub Notifications
+
+Notifications play a crucial role in keeping us updated with the activities related to our projects on GitHub. However, it can sometimes become overwhelming due to the sheer volume. Here's a guide to help you manage your GitHub notifications efficiently and reduce unnecessary noise.
+
+## Step 1: Understanding the Source of Notifications
+
+GitHub sends notifications based on your interactions and subscriptions on the platform. By default, you're subscribed to conversations when:
+
+- You've not disabled automatic watching for repositories or teams you've joined.
+
+- You're assigned to an issue or pull request.
+
+- You've opened a pull request or issue.
+
+- You've commented on a thread.
+
+- You've manually subscribed to a thread by clicking Watch or Subscribe.
+
+- Your username or team you're a member of is @mentioned.
+
+- You've changed the state of a thread, such as closing an issue or merging a pull request.
+
+## Step 2: Unsubscribe from Unwanted Notifications
+
+If you want to unsubscribe from certain conversations, you can:
+
+1. **Visit the Conversation:** Navigate to the specific issue, pull request, or gist that you're receiving notifications from.
+
+2. **Unsubscribe:** Look for the 'Unsubscribe' button on the right side of the conversation page and click it. This will prevent further notifications from this particular thread.
+
+## Step 3: Managing Repository Subscriptions
+
+To unsubscribe from a repository:
+
+1. **Visit the Repository:** Navigate to the main page of the repository.
+
+2. **Change Watch Status:** On the top right, you'll see a 'Watch' button. Click it and select 'Unwatch'. This prevents you from receiving notifications from this repository.
+
+## Step 4: Managing Default Subscriptions
+
+You can also control your default subscription settings:
+
+1. **Visit Your Settings:** Click your profile picture in the top right corner, then select 'Settings'.
+
+2. **Navigate to Notifications:** In the left sidebar, select 'Notifications'.
+
+3. **Configure Your Settings:** Here, you can control the default watching behavior, decide how you'd like to receive notifications, and customize your email preferences.
+
+Remember, you can also customize your notifications inbox to focus on the notifications you care most about, using filters, custom work-flows, and saving important notifications.
+
+It's important to manage your GitHub notifications to focus on what matters most and avoid being overwhelmed. Take some time to adjust these settings according to your needs.
+
+For more details, you can always refer to the official GitHub documentation on [Managing your subscriptions](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/managing-your-subscriptions) and [Configuring notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/configuring-notifications).
+
+If you're still receiving unwanted notifications, consider reviewing your email headers, which show the intended recipient. If you need any further assistance or have feedback or feature requests for notifications, consider using our #github-community discussion in slack.
+
+## Useful Links
+
+These links will show your personal GitHub notification settings:
+
+- [https://github.com/settings/notifications](https://github.com/settings/notifications)
+- [https://github.com/watching](https://github.com/watching)
+- [https://github.com/notifications/subscriptions](https://github.com/notifications/subscriptions)

--- a/source/documentation/information/self-managed-github-teams.html.erb.md
+++ b/source/documentation/information/self-managed-github-teams.html.erb.md
@@ -1,0 +1,63 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Self-Managed GitHub Teams
+last_reviewed_on: 2023-08-31
+review_in: 3 months
+---
+
+# GitHub Self-Managed Teams (Beta)
+
+GitHub Self-Managed Teams is an opt-in, automated solution currently in beta testing. It helps manage team members' activity by allowing you to set rules to monitor user activity, send notifications, and remove users as needed. The system runs on the first of every month and can be tailored to your team's specific needs through a simple configuration.
+
+**Definition:** User activity is currently defined as "commits made to any repository a team has access to". This will expand over time and we welcome suggestions for additional activity types.
+
+## Features
+
+1. **Monitor Activity**: Checks users' activity in the specified repositories.
+
+2. **Automated Removal**: Option to automatically remove inactive users from the team.
+
+3. **Slack Notifications**: Sends a notification to a specified Slack channel regarding the removals.
+
+4. **Ignore Specific Users and Repositories**: Exclude certain users or repositories from the checks.
+
+## How to Opt In
+
+Being an opt-in feature in beta testing, you can enable GitHub Self-Managed Teams by creating a configuration block in this [TOML file](https://github.com/ministryofjustice/operations-engineering/blob/main/config/inactive-users.toml). Here's an example:
+
+```toml
+[team.operations_engineering]
+github_team = "operations-engineering"
+slack_channel = "#operations-engineering-alerts"
+remove_from_team = true
+users_to_ignore = [ "cloud-platform-moj", "ScottSeaward" ]
+repositories_to_ignore = [ "operations-engineering-reports" ]
+```
+
+The only required fields are `github_team` and `remove_from_team`. The other fields are optional and can be omitted if you don't want to use them.
+
+### Configuration Options
+
+- `github_team`: The GitHub team you want to manage.
+- `slack_channel`: The Slack channel where notifications will be sent.
+- `remove_from_team`: Set to `true` if you want to remove inactive users from the team; `false` if not.
+- `users_to_ignore`: A list of GitHub usernames to be ignored during the check.
+- `repositories_to_ignore`: A list of repositories you don't want to be checked.
+
+## What Happens During the Check?
+
+On the first of every month, a GitHub Action runs and performs the following actions:
+
+1. Identifies users who haven't committed to repositories the specified GitHub team manages.
+
+2. If `remove_from_team` is set to `true`, the job removes users who haven't made a commit.
+
+3. Send an informative message to a specified Slack channel (if one is specified in your team configuration block).
+
+## Support and Assistance
+
+Since this feature is in beta testing, your feedback and insights are invaluable to us. If you need any assistance, have questions, or encounter any issues, please feel free to contact us in the **[#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4)** Slack channel.
+
+## Opting Out
+
+If you wish to opt out of this feature, simply remove your teams' corresponding configuration block from the TOML file.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -37,8 +37,11 @@ This guide is designed for developers, power users, and all team members at the 
 * [Repository Template](documentation/information/mojrepotemplate.html)
 * [Repository Standards](documentation/information/mojrepostandards.html)
 * [Automatically configure Repository Standards](documentation/information/auto-configure-standards.html)
-* [How to Store Code Privately](documentation/information/storing-code-in-private.html)
-* [How to Store Code Publicly](documentation/information/storing-code-in-public.html)
+* [Add a Compliance Badge To Your README](documentation/information/add-repo-badge.html)
+* [Tips on Managing Notifications](documentation/information/managing-github-notifications.html)
+* [Self Managed Teams Beta](documentation/information/self-managed-github-teams.html)
+* [Advice: Store Code Privately](documentation/information/storing-code-in-private.html)
+* [Advice: Store Code Publicly](documentation/information/storing-code-in-public.html)
 
 #### Monitoring and Alerting
 


### PR DESCRIPTION
These should be managed in this repository.
