### PR TITLE
Move OS Data Hub to Additional Resources section

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Operations Engineering
-last_reviewed_on: 2023-10-30
+last_reviewed_on: 2023-11-01
 review_in: 6 months
 ---
 
@@ -68,13 +68,13 @@ This guide is designed for developers, power users, and all team members at the 
 
 #### Project Management
 
-* [OS Data Hub APIs](documentation/services/osdatahubapi.html)
 * [Zenhub](documentation/services/zenhub.html)
 
 #### Additional Resources
 
 * [Auth0 Account](documentation/services/auth0account.html)
 * [MoJ Acronyms](https://ministry-of-justice-acronyms.service.justice.gov.uk)
+* [OS Data Hub APIs](documentation/services/osdatahubapi.html)
 
 ### Organisational Fit
 


### PR DESCRIPTION
Moving index link for OS Data Hub to other resources as it's not a Project Management tool and doesn't fit with other sections.