### PR TITLE
Replace defensive domain registration link

### DIFF
--- a/source/documentation/services/domainmgt.html.md.erb
+++ b/source/documentation/services/domainmgt.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Domain Management
-last_reviewed_on: 2023-08-02
+last_reviewed_on: 2023-11-15
 review_in: 6 months
 ---
 
@@ -14,7 +14,7 @@ Operations Engineering is the Domain Registrar for the Ministry of Justice.
 We manage all the domains and provide the following services:
 
 - purchase and registration of new domains
-- [defensive domain registration](https://github.com/ministryofjustice/dns#defensive-domain-management)
+- [defensive domain registration](https://security-guidance.service.justice.gov.uk/defensive-domain-registration/#defensive-domain-registrations)
 - enforcing [naming standards](https://ministryofjustice.github.io/technical-guidance/documentation/standards/naming-domains.html#naming-domains) for service.justice.gov.uk and justice.gov.uk domains
 - changes to DNS records managed in MoJDSD AWS account
 - transfer of domains from another Domain Registrar to Ministry of Justice


### PR DESCRIPTION
This PR replaces the link to the archived DNS repository with a link to the policy and process for defensive domain registration in the MoJ security guidance.