### PR TITLE
Updates services we dont support page

### DIFF
--- a/source/documentation/information/we-dont-do-that.html.md.erb
+++ b/source/documentation/information/we-dont-do-that.html.md.erb
@@ -13,62 +13,66 @@ This is a list (not comprehensive) of common requests we recieve for services th
 
 Please raise a new issue here [Data-Platform-Support](https://github.com/ministryofjustice/data-platform-support/issues/new/choose)
 
+## Azure App Insights
+
+Please contact [ask-digital-studio-ops](https://moj.enterprise.slack.com/archives/C6D94J81E) Slack channel
+
 ## BrowserStack
 
-Please contact #digital_it_forum slack channel
+Please contact [digital_it_forum](https://moj.enterprise.slack.com/archives/C0282GUGKL7) Slack channel
 
 ## Cloud Platform related requests
 
-Please contact #ask-cloud-platform slack channel
+Please contact [ask-cloud-platform](https://moj.enterprise.slack.com/archives/C57UPMZLY) Slack channel
 
 ## Confluence
 
-Please contact #digital_it_forum slack channel
+Please contact [digital_it_forum](https://moj.enterprise.slack.com/archives/C0282GUGKL7) Slack channel
 
 ## Dynamic Host Configuration Protocol (DHCP)
 
-Please contact #network-operations or #ask-nvvs-devops slack channel
+Please contact [network-operations](https://moj.enterprise.slack.com/archives/C01CLTGTXT7) or [ask-nvvs-devops](https://moj.enterprise.slack.com/archives/C026AFE617T) Slack channel
 
 ## Figma
 
-Please contact #digital_it_forum slack channel
+Please contact [digital_it_forum](https://moj.enterprise.slack.com/archives/C0282GUGKL7) Slack channel
 
 ## GSuite or other Google Apps/Features
 
-Please contact #digital_it_forum slack channel
+Please contact [digital_it_forum](https://moj.enterprise.slack.com/archives/C0282GUGKL7) slack channel
 
 ## JIRA
 
-Please contact #digital_it_forum slack channel
+Please contact [digital_it_forum](https://moj.enterprise.slack.com/archives/C0282GUGKL7) Slack channel
 
 ## LucidChart
 
-Please contact #digital_it_forum slack channel
+Please contact [digital_it_forum](https://moj.enterprise.slack.com/archives/C0282GUGKL7) Slack channel
 
 ## Modernisation Platform related requests
 
-Please contact #ask-modernisation-platform slack channel
+Please contact [ask-modernisation-platform](https://moj.enterprise.slack.com/archives/C01A7QK5VM1) Slack channel
 
 ## MS Teams
 
-Please contact #digital_it_forum slack channel
+Please contact [digital_it_forum](https://moj.enterprise.slack.com/archives/C0282GUGKL7) Slack channel
 
 ## Ordering IT Equipment
 
-Please contact #digital_it_forum slack channel
+Please contact [digital_it_forum](https://moj.enterprise.slack.com/archives/C0282GUGKL7) Slack channel
 
 ## Sharepoint
 
-Please contact #digital_it_forum slack channel
+Please contact [digital_it_forum](https://moj.enterprise.slack.com/archives/C0282GUGKL7) Slack channel
 
 ## Slack
 
-Please contact #digital_it_forum slack channel
+Please contact [digital_it_forum](https://moj.enterprise.slack.com/archives/C0282GUGKL7) Slack channel
 
 ## Trello
 
-Please contact #digital_it_forum slack channel
+Please contact [digital_it_forum](https://moj.enterprise.slack.com/archives/C0282GUGKL7) Slack channel
 
 ## VPN questions
 
-Please contact #digital_it_forum slack channel
+Please contact [digital_it_forum](https://moj.enterprise.slack.com/archives/C0282GUGKL7) Slack channel


### PR DESCRIPTION
This PR updates the 'Services We Don't Support' page with the correct team to contact for Azure App Insights requests.  It also changes the Slack channel info to a direct to that channel.