### PR TITLE
🔥 Remove references to DNS-IAC

### DIFF
--- a/source/documentation/services/domainmgt.html.md.erb
+++ b/source/documentation/services/domainmgt.html.md.erb
@@ -29,5 +29,3 @@ There is no charge for any of the above services. Costs are met centrally by Pla
 ## Support
 
 If you require any of these services please contact #ask-operations-engineering slack channel or [domains@digital.justice.gov.uk](mailto:domains@digital.justice.gov.uk).
-
-Alternativly you can submit your DNS changes as a pull request (PR) against our [DNS Infrastructure as Code repository](https://github.com/ministryofjustice/dns-iac)


### PR DESCRIPTION
## 👀 Purpose
- To ensure users aren't confused by old references to the soon-to-be-archived DNS-IAC repository

## ♻️ What's changed
- All references to DNS-IAC have been removed (excluding the ADR)