### PR TITLE
🆙 Update content on the processes to join the GitHub Organisation to clarify different user journeys

### DIFF
--- a/source/documentation/information/mojgithubenterprise.html.md.erb
+++ b/source/documentation/information/mojgithubenterprise.html.md.erb
@@ -41,10 +41,10 @@ our [Dos and Don't Guide for Public Repositories](https://user-guide.operations-
 
 ## Access Management
 
-### Joining Ministry of Justice/MoJ Analytical Services Organisation
-
 Operations Engineering is responsible for granting access to both the Ministry of Justice and the MoJ Analytical
 Services Organisations.
+
+### Joining Ministry of Justice/MoJ Analytical Services Organisation
 
 If you require access to these organisations, you can contact us via our Slack
 channel [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4) or email us
@@ -71,12 +71,12 @@ If you already have a GitHub account and wish to use it for work, you should add
 your [primary email](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/changing-your-primary-email-address)
 address in GitHub.
 
-#### Single Sign On (SSO) for Ministry of Justice Organisation
+### Single Sign On (SSO) for Ministry of Justice Organisation
 
 If you have a `@digital.justice.gov.uk` and only require access to the Ministry of Justice Organisation, you can use
 [SSO](https://github.com/orgs/ministryofjustice/sso) to gain access via your Google Workspace account.
 
-#### Third-Party Supplier Management
+### Third-Party Supplier Management
 
 If you are a Third-Party Supplier who is maintaining code on behalf of the Ministry of Justice, you will need to be
 added as

--- a/source/documentation/information/mojgithubenterprise.html.md.erb
+++ b/source/documentation/information/mojgithubenterprise.html.md.erb
@@ -92,37 +92,27 @@ repository for the organisation below:
 - MoJ Analytical
   Services = [moj-analytical-services/github-outside-collaborators](https://github.com/moj-analytical-services/github-outside-collaborators)
 
-### Third-Party Application and Integration Approval
-We review and approve requests to integrate third-party apps, keeping our tech ecosystem secure and efficient.
+## Our Services and Support
 
-### Fine-Grained Personal Access Token Requests
+As the custodians of these GitHub organisations, our team is responsible for the following:
 
-We oversee the approval of such requests, ensuring secure and proper usage of GitHub.
+- **Team Management:** Where teams lack a maintainer, we step in to manage team dynamics and operations.
 
-## Safety Nets
+- **Third-Party Application and Integration Approval:** We review and approve requests to integrate third-party apps,
+  keeping our tech ecosystem secure and efficient.
 
-### Team Management
+- **Fine-Grained Personal Access Token Requests:** We oversee the approval of such requests, ensuring secure and proper
+  usage of GitHub.
 
-Where teams lack a maintainer, we step in to manage team dynamics and operations.
+- **Repository Compliance:** We check that all repositories align with
+  the [MoJ GitHub Repository Standards](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojrepostandards.html#github-repository-standards-in-the-ministry-of-justice).
 
-### Account Automation
+- **Repository Templates Management:** We provide and manage templates for repositories, promoting best practices and
+  consistency across projects.
 
-We automate account management tasks like archiving inactive users and repositories, maintaining a clean and efficient
-workspace.
+- **Enterprise Support:** We liaise with GitHub to resolve any issues and to get support for our enterprise instance.
 
-## Standards
-
-### Repository Compliance
-
-We check that all repositories align with
-the [MoJ GitHub Repository Standards](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojrepostandards.html#github-repository-standards-in-the-ministry-of-justice).
-
-### Repository Templates Management
-
-We provide and manage templates for repositories, promoting best practices and consistency across projects.
-
-### Support
-
-- Enterprise Support: We liaise with GitHub to resolve any issues and to get support for our enterprise instance.
+- **Account Automation:** We automate account management tasks like archiving inactive users and repositories,
+  maintaining a clean and efficient workspace.
 
 

--- a/source/documentation/information/mojgithubenterprise.html.md.erb
+++ b/source/documentation/information/mojgithubenterprise.html.md.erb
@@ -1,47 +1,128 @@
 ---
 owner_slack: "#operations-engineering-alerts"
-title: MoJ GitHub Enterprise Management
+title: GitHub
 last_reviewed_on: 2023-10-04
 review_in: 6 months
 ---
 
-# MoJ GitHub Enterprise Management
+# GitHub
 
-The Operations Engineering team proudly manages the [Ministry of Justice GitHub Enterprise](https://github.com/enterprises/ministry-of-justice-uk). We maintain and support our enterprise instance, which includes several organisations:
+## Enterprise Account
+
+The Operations Engineering team manages
+the [Ministry of Justice GitHub Enterprise](https://github.com/enterprises/ministry-of-justice-uk). We maintain and
+support our enterprise instance, which includes several organisations:
 
 - [Ministry of Justice](https://github.com/ministryofjustice)
 - [MoJ Analytical Services](https://github.com/moj-analytical-services)
-- [ministryofjustice-test](https://github.com/ministryofjustice-test)
-- [Criminal Injuries Compensation Authority](https://github.com/CriminalInjuriesCompensationAuthority)
+- [Criminal Injuries Compensation Authority](https://github.com/CriminalInjuriesCompensationAuthority) *
+  *_though it sits within the Enterprise Account, this organisation is not managed by Operations Engineering_*
 
-## Why We Use GitHub
+### Actions Quota for Private and Internal Repositories
 
-GitHub is a powerful tool for software development and collaboration. Here's why we use it:
+> The Ministry of Justices' GitHub Enterprise account reserves the following usage quotas for GitHub Actions (per
+month):
+>
+> - **50,000** Minutes
+> - **50GB** Storage
 
-- Version Control: GitHub is built on Git, which tracks changes to our code over time. This ensures that every revision is documented, and we can revert to an older version if necessary.
+The quota renews at the start of each month and is a shared quota across all private and internal repositories in
+MoJs GitHub Enterprise account.
 
-- Collaboration: GitHub's collaborative features make it easy for our teams to work together, regardless of their physical location. Developers can contribute to projects, review code, and discuss changes.
+Teams are responsible for actively managing their usage of actions for private and internal repositories. Reaching these
+limits means that the service will be unavailable for private and internal repositories until the next reset.
 
-- Integration: GitHub integrates well with many popular tools in the development ecosystem, allowing us to build efficient and flexible workflows.
+_**These limits do not apply to public repositories.**_
 
-## Our Services and Support
+If you are considering making your repository public, consider reading the technical guidance
+on [converting private or internal repositories to public](https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#private-repositories)
+and
+our [Dos and Don't Guide for Public Repositories](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-code-in-public.html).
 
-As the custodians of these GitHub organisations, our team is responsible for the following:
+## Access Management
 
-- **Access Management:** We handle user access control, ensuring the right people have access to the right resources.
+### Joining Ministry of Justice/MoJ Analytical Services Organisation
 
-- **Third-Party Collaborator Management:** We vet and [manage collaborations with third-party developers](https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#outside-collaborator), safeguarding the integrity of our projects.
+Operations Engineering is responsible for granting access to both the Ministry of Justice and the MoJ Analytical
+Services Organisations.
 
-- **Team Management:** Where teams lack a maintainer, we step in to manage team dynamics and operations.
+If you require access to these organisations, you can contact us via our Slack
+channel [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4) or email us
+at [Operations Engineering](mailto:operations-engineering@digital.justice.gov.uk).
 
-- **Third-Party Application and Integration Approval:** We review and approve requests to integrate third-party apps, keeping our tech ecosystem secure and efficient.
+> You must provide an email address that we can send the invitation to. We only allow access to the following
+pre-approved email addresses:
+>
+> - @cica.gov.uk
+> - @digital.justice.gov.uk
+> - @ima-citizensrights.org.uk
+> - @judicialappointments.gov.uk
+> - @judiciary.uk
+> - @justice.gov.uk
+> - @ppo.gov.uk
+> - @publicguardian.gov.uk
+> - @sentencingcouncil.gov.uk
+> - @yjb.gov.uk
 
-- **Fine-Grained Personal Access Token Requests:** We oversee the approval of such requests, ensuring secure and proper usage of GitHub.
+If you do not have a GitHub account, the invitation you receive will prompt you to create one before joining the
+organisation.
 
-- **Repository Compliance:** We check that all repositories align with the [MoJ GitHub Repository Standards](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojrepostandards.html#github-repository-standards-in-the-ministry-of-justice).
+If you already have a GitHub account and wish to use it for work, you should add your work email as
+your [primary email](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/changing-your-primary-email-address)
+address in GitHub.
 
-- **Repository Templates Management:** We provide and manage templates for repositories, promoting best practices and consistency across projects.
+#### Single Sign On (SSO) for Ministry of Justice Organisation
 
-- **Enterprise Support:** We liaise with GitHub to resolve any issues and to get support for our enterprise instance.
+If you have a `@digital.justice.gov.uk` and only require access to the Ministry of Justice Organisation, you can use
+[SSO](https://github.com/orgs/ministryofjustice/sso) to gain access via your Google Workspace account.
 
-- **Account Automation:** We automate account management tasks like archiving inactive users and repositories, maintaining a clean and efficient workspace.
+#### Third-Party Supplier Management
+
+If you are a Third-Party Supplier who is maintaining code on behalf of the Ministry of Justice, you will need to be
+added as
+an [Outside Collaborator](https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#outside-collaborator).
+
+Outside Collaborators will only be able to gain access to specific repositories.
+
+If you require access/need to give access to an Outside Collaborator, raise an issue or pull request in the relevant
+repository for the organisation below:
+
+- Ministry of
+  Justice = [ministryofjustice/github-collaborators](https://github.com/ministryofjustice/github-collaborators)
+- MoJ Analytical
+  Services = [moj-analytical-services/github-outside-collaborators](https://github.com/moj-analytical-services/github-outside-collaborators)
+
+### Third-Party Application and Integration Approval
+We review and approve requests to integrate third-party apps, keeping our tech ecosystem secure and efficient.
+
+### Fine-Grained Personal Access Token Requests
+
+We oversee the approval of such requests, ensuring secure and proper usage of GitHub.
+
+## Safety Nets
+
+### Team Management
+
+Where teams lack a maintainer, we step in to manage team dynamics and operations.
+
+### Account Automation
+
+We automate account management tasks like archiving inactive users and repositories, maintaining a clean and efficient
+workspace.
+
+## Standards
+
+### Repository Compliance
+
+We check that all repositories align with
+the [MoJ GitHub Repository Standards](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojrepostandards.html#github-repository-standards-in-the-ministry-of-justice).
+
+### Repository Templates Management
+
+We provide and manage templates for repositories, promoting best practices and consistency across projects.
+
+### Support
+
+- Enterprise Support: We liaise with GitHub to resolve any issues and to get support for our enterprise instance.
+
+


### PR DESCRIPTION
## 👀 Purpose
- connects to [Define and Document the GitHub Organisation Onboarding Process#3792](https://github.com/ministryofjustice/operations-engineering/issues/3792)
- To explicitly define how people should join our organisation and the potential different users journeys involved

## ♻️ What's changed
- Added documentation to explicitly define the different user journeys of someone trying to join one of our organisations, including:
	- Generally joining an org using a pre-defined allowed email
	- Using SSO to join MoJ with a @digital.justice.gov.uk email
	- Adding outside collaborators
- Restructured the document this information sits in, so it didn't look as out of place
- Added some information about our enterprise and quotas, with some text to explain that teams are responsible for managing their usage

## 📝 Notes
- I decided not to fill in the rest of the page with more detailed information, as I believe we have some separate tickets for it - and these should be updated with the proper attention given to them
- It may be worth breaking this page up, as this information is fairly useful - but is currently hard to find from our landing page (but I thought I'd leave this for now, potentially a content structure review at some point 🤔 )