### PR TITLE
:recycle: Rename all erb files to md for megalinter

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -36,6 +36,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # If you use VALIDATE_ALL_CODEBASE = true, you can remove this line to improve performances
 
+      # Ensure all files have the correct file extension
+      - name: Rename .html.md.erb to .html.md
+        run: make rename-md-erb
+
       # MegaLinter
       - name: MegaLinter
         id: ml

--- a/makefile
+++ b/makefile
@@ -21,3 +21,10 @@ check:
 		-v $$(pwd)/config:/app/config \
 		-v $$(pwd)/source:/app/source \
 		-it $(IMAGE) /scripts/check-url-links.sh
+
+
+# Rule to rename .html.md.erb to .html.md
+rename-md-erb:
+	@find . -type f -name '*.html.md.erb' -exec sh -c 'mv "$$0" "$${0%.erb}"' {} \;
+
+.PHONY: rename-md-erb


### PR DESCRIPTION
The megalinter will only check files with a .md file extension. This command performs a search and change on all erb files.
