### PR TITLE
Updates review dates

### DIFF
--- a/source/documentation/information/auto-configure-standards.html.md.erb
+++ b/source/documentation/information/auto-configure-standards.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Automatically configure GitHub Repository Standards
-last_reviewed_on: 2023-12-06
+last_reviewed_on: 2024-03-06
 review_in: 3 months
 ---
 

--- a/source/documentation/information/we-dont-do-that.html.md.erb
+++ b/source/documentation/information/we-dont-do-that.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Services We Don't Manage
-last_reviewed_on: 2023-12-06
+last_reviewed_on: 2024-03-06
 review_in: 3 months
 ---
 


### PR DESCRIPTION
This PR updates the review dates for the following documents:

- [Automatically configure GitHub Repository Standards](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/auto-configure-standards.html)
- [Services We Don't Manage](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/we-dont-do-that.html)