### PR TITLE
Update Sentry session replay limit from 500 to 800000 per month

### DIFF
--- a/source/documentation/services/sentry.html.md.erb
+++ b/source/documentation/services/sentry.html.md.erb
@@ -21,7 +21,7 @@ tool for digital products.
 > - 30 Million [Transactions](https://docs.sentry.io/product/performance/transaction-summary/#what-is-a-transaction)
 > - 4 Million Errors
 > - 1 Gb of Attachments
-> - 500 Replays
+> - 800000 Replays
 >
 > The quota renews on the 14th of each month and is shared across all projects in Sentry.
 


### PR DESCRIPTION
Updated the sentry session Replays have been updated from 500 to 800,000 a month.