### PR TITLE
Add note about `invalid` badge status

### DIFF
--- a/source/documentation/information/add-repo-badge.html.md.erb
+++ b/source/documentation/information/add-repo-badge.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Add a Ministry of Justice Compliance Badge to Your Repository
-last_reviewed_on: 2024-05-27
+last_reviewed_on: 2024-06-12
 review_in: 3 months
 ---
 
@@ -13,7 +13,7 @@ The operations engineering team has created a dynamic compliance badge that you 
 
 We're leveraging img.shields.io, a service that provides dynamically generated badge images, to show the compliance status of your repository. When added to a repository, the badge queries our report system to obtain the repository's compliance status. If your repository is compliant, a pleasingly blue "MoJ Compliant" badge will show up on your landing page. If your repository is not compliant, a red "MoJ Non-Compliant" badge will show up instead.
 
-Please note that this badge only works with public repositories and is not compatible with private or internal ones.
+Please note that this badge only works with public repositories and is not compatible with private or internal ones. Also as the status of the badge is linked to the Standards Dashboard, it may show as `invalid` until the report is refreshed within a 24 hrs period.
 
 For a visual representation of the badge, refer to the discussion in the [operations-engineering](https://github.com/ministryofjustice/operations-engineering/discussions/717) team.
 

--- a/source/documentation/services/sentry.html.md.erb
+++ b/source/documentation/services/sentry.html.md.erb
@@ -32,7 +32,7 @@ Our Sentry plan also includes [performance monitoring].
 
 ### Error Spike Protection
 The Operations Engineering team have enabled
-the [Spike Protection](https://docs.sentry.io/product/accounts/quotas/spike-protection/) feature at an organisational
+the [Spike Protection](https://docs.sentry.io/pricing/quotas/spike-protection/) feature at an organisational
 level.
 
 Sentry uses an algorithm to keep track of ***normal*** error consumption per project. When an abnormal amount of
@@ -70,7 +70,7 @@ worse case scenario regarding excessive error consumption.
 See the Sentry [Rate limiting] documentation to set up rate limiting for each project.
 
 Also see
-the [Setting Useful Rate Limits](https://docs.sentry.io/product/accounts/quotas/manage-event-stream-guide/#-how-to-set-proper-rate-limits)
+the [Setting Useful Rate Limits](https://docs.sentry.io/pricing/quotas/manage-event-stream-guide/#setting-useful-rate-limits)
 documentation to help create a suitable rate limit for your application.
 
 ### Removing/Ignoring Errors
@@ -181,8 +181,6 @@ assistance in setting up transaction filtering / rate limiting within your Sentr
 
 [Transactions]: https://docs.sentry.io/product/performance/transaction-summary/#what-is-a-transaction
 
-[Delete and Discard]: https://docs.sentry.io/product/accounts/quotas/manage-event-stream-guide/#:~:text=Delete%20%26%20Discard&text=If%20there%20is%20an%20irrelevant,filter%20out%20future%20matching%20events
-
 [Sentry.io]: https://sentry.io
 
 [MoJ GitHub Organization]: https://github.com/ministryofjustice
@@ -193,7 +191,7 @@ assistance in setting up transaction filtering / rate limiting within your Sentr
 
 [performance monitoring]: https://docs.sentry.io/product/performance/
 
-[Rate limiting]: https://docs.sentry.io/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting
+[Rate limiting]: https://docs.sentry.io/pricing/quotas/manage-event-stream-guide/#rate-limiting
 
 [Express]: https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/blob/2ddc0684fb8b2e08642440899d56de8765e509da/server.js#L69-L97
 
@@ -201,7 +199,7 @@ assistance in setting up transaction filtering / rate limiting within your Sentr
 
 [Django]: https://github.com/ministryofjustice/cla_frontend/blob/51a6c5a05597384c780041dd810c9108c9b575bb/cla_frontend/settings/base.py#L57-L65
 
-[protecting User privacy in Session Replay]: https://docs.sentry.io/product/session-replay/protecting-user-privacy/
+[protecting User privacy in Session Replay]: https://docs.sentry.io/security-legal-pii/scrubbing/protecting-user-privacy/
 
 [Sampling]: https://docs.sentry.io/platforms/javascript/session-replay/?original_referrer=https%3A%2F%2Fdocs.sentry.io%2F#sampling
 

--- a/source/documentation/services/sentry.html.md.erb
+++ b/source/documentation/services/sentry.html.md.erb
@@ -151,7 +151,7 @@ In addition to setting sample rates, you can also use the [beforeErrorSampling](
 
 Sentry's Session Replay is not an actual “screen” recording, but instead a recording of changes in the web browser's Document Object Model (DOM) (i.e., the data representation of the page). This important distinction means that the data captured by session Replay can be searched and stripped.
 
-For full details of Privacy and additional configuration, please refer to Sentry.io [Protecting User Privacy in Session Replay](https://docs.sentry.io/product/session-replay/protecting-user-privacy/) guidance.
+For full details of Privacy and additional configuration, please refer to Sentry.io [Protecting User Privacy in Session Replay](https://docs.sentry.io/security-legal-pii/scrubbing/protecting-user-privacy/) guidance.
 
 ### Privacy Configuration
 


### PR DESCRIPTION
## 👀 Purpose

- Adds additional user guidance to warn users that badge may show an `invalid` status until the Standards Dashboard is updated, which only happens once a day.
- Fixes failing link checker. Sentry have refreshed some user docs so links have moved in their user docs. 

## ♻️ What's changed

- Added additional guidance.
- Fixes various links to Sentry user docs