### PR TITLE
Fix for duplicate word

### DIFF
--- a/source/documentation/information/mojrepostandards.html.md.erb
+++ b/source/documentation/information/mojrepostandards.html.md.erb
@@ -31,7 +31,7 @@ To read more about why we have these standards, please see our [technical standa
 
 ## How to apply the standards
 
-We have tried to make these standards easy to apply. Most of these standards are either applied by making changes to repository setting or adding adding a file to the repository.
+We have tried to make these standards easy to apply. Most of these standards are either applied by making changes to repository setting or adding a file to the repository.
 
 To make applying the standard even easier we also provide an opt-in feature to [automate the configuration](auto-configure-standards.html) of a majority of the standards using a "topic".
 


### PR DESCRIPTION
PR removes duplicate word from:
[Repository Standards](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojrepostandards.html)