### PR TITLE
Add "How to get, register or manage a domain name"

### DIFF
--- a/source/documentation/services/domain-naming-standard.html.md.erb
+++ b/source/documentation/services/domain-naming-standard.html.md.erb
@@ -14,7 +14,7 @@ may be eligible for a `*.justice.gov.uk` domain.
 ## Getting a domain
 
 Please refer to [How to get, register or manage a domain name]
-(https://technical-guidance.service.justice.gov.uk/documentation/standards/how-to-get-a-domain-name.html).
+(how-to-get-a-domain-name.html).
 
 ## Which domain do I need?
 
@@ -109,7 +109,7 @@ For example the Welsh language version of `magistrates.judiciary.uk` should be `
 Domains that don't end in `.gov.uk` should not be used for MOJ services.
 
 If you use one, please refer to [How to get, register or manage a domain name]
-(https://technical-guidance.service.justice.gov.uk/documentation/standards/how-to-get-a-domain-name.html). The Operations Engineering team will provide
+(how-to-get-a-domain-name.html). The Operations Engineering team will provide
 you with a `.gov.uk` domain as set out above, and will help you deprecate your
 old domain.
 

--- a/source/documentation/services/how-to-get-a-domain-name.html.md.erb
+++ b/source/documentation/services/how-to-get-a-domain-name.html.md.erb
@@ -14,7 +14,7 @@ Domains used within the MOJ must follow the [naming domains]
 (https://user-guide.operations-engineering.service.justice.gov.uk/documentation/services/domainmgt.html).
 
 As per the [Naming domains guidance]
-(naming-domains.html#non-gov-uk-domains), the use of non-`gov.uk` domain names
+(domain-naming-standard.html#non-gov-uk-domains), the use of non-`gov.uk` domain names
 is strongly discouraged.
 
 ## Requesting a new domain or changes to an existing domain
@@ -25,7 +25,7 @@ If you need to request a new domain or changes to an existing domain name,
 
 The Operations Engineering team will help ensure that your domain meets the
 [naming domains standard](domain-naming-standard.html) and our [wider standards for
-naming things](naming-things.html). The Operations Engineering team will also
+naming things](https://technical-guidance.service.justice.gov.uk/documentation/standards/naming-things.html). The Operations Engineering team will also
 help identify which subdomain is most appropriate for your service.
 
 You **must not** register a domain outside of the Operations Engineering team.

--- a/source/documentation/services/how-to-get-a-domain-name.html.md.erb
+++ b/source/documentation/services/how-to-get-a-domain-name.html.md.erb
@@ -1,0 +1,166 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: How to get, register or manage a domain name
+last_reviewed_on: 2024-12-06
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+The MOJ centrally registers and maintains domains for use across the department.
+Domains used within the MOJ must follow the [naming domains]
+(domain-naming-standard.html) standards and must be registered by the MOJ's
+[Operations Engineering team]
+(https://user-guide.operations-engineering.service.justice.gov.uk/documentation/services/domainmgt.html).
+
+As per the [Naming domains guidance]
+(naming-domains.html#non-gov-uk-domains), the use of non-`gov.uk` domain names
+is strongly discouraged.
+
+## Requesting a new domain or changes to an existing domain
+
+If you need to request a new domain or changes to an existing domain name,
+[email the Operations Engineering team]
+(mailto:domains@digital.justice.gov.uk).
+
+The Operations Engineering team will help ensure that your domain meets the
+[naming domains standard](domain-naming-standard.html) and our [wider standards for
+naming things](naming-things.html). The Operations Engineering team will also
+help identify which subdomain is most appropriate for your service.
+
+You **must not** register a domain outside of the Operations Engineering team.
+
+> Note - There are seperate processes for new gov.uk domains. If you are seeking a gov.uk or service.gov.uk domain you should [Check if your organisation can get a .gov.uk domain name](https://www.gov.uk/guidance/check-if-your-organisation-can-get-a-govuk-domain-name) in the first instance.
+
+## Moving your domain to the central register
+
+If you currently use or have registered a non-`gov.uk` domain, you **must**
+transfer the domain to the Operations Engineering team. The Operations
+Engineering team will:
+
+- provide you with a new domain that meets [naming domains]
+  (domain-naming-standard.html) standards
+- redirect your old domain to your new domain
+- help you decommission and deprecate your old domain
+
+## Defensive domain registrations
+
+Defensive domains must be requested through the [Operations Engineering team]
+(mailto:domains@digital.justice.gov.uk).
+
+The MOJ's [Security Guidance]
+(https://security-guidance.service.justice.gov.uk/defensive-domain-registration/#defensive-domain-registrations)
+covers why we defensively register domain names.
+
+## Deprecating domains
+
+If you need to deprecate a domain (both `gov.uk` and non-`gov.uk`), please
+contact the [Operations Engineering team]
+(mailto:domains@digital.justice.gov.uk).
+
+The Operations Engineering team will ensure it:
+
+- redirects to your new domain, if applicable
+- has the correct DNS records set for a domain that has been deprecated
+
+### List of deprecated domains
+
+The MOJ no longer supports:
+
+- *.dsd.io, which was previously used for non-production services
+
+## Mandatory DNS records for domains
+
+If you have DNS delegation for a subdomain, you must set the following DNS
+records yourselves. If you do not have DNS delegation, the Operations
+Engineering team will set these to the appropriate value for you.
+
+### Functional nameservers
+
+Your domain must always have functional nameservers.
+
+### Sender Policy Framework (SPF)
+
+Your domain must always have a `TXT` record for SPF set.
+
+For example, if your domain does not send emails, you would set a `TXT` record
+to:
+
+`v=spf1 -all`
+
+Additional guidance is available on [GOV.UK's SPF implementation guidance]
+(https://www.gov.uk/government/publications/email-security-standards/sender-policy-framework-spf).
+
+### Domain-based Message Authentication, Reporting and Conformance (DMARC)
+
+Your domain must always have a DMARC record configured in line with the
+[GOV.UK's DMARC guidance]
+(https://www.gov.uk/government/publications/email-security-standards/domain-based-message-authentication-reporting-and-conformance-dmarc).
+
+For example, to set a reject policy, you would set a `TXT` record on
+`_dmarc.mydomain.gov.uk` to:
+
+`v=DMARC1;p=reject;rua=mailto:dmarc-rua@dmarc.service.gov.uk;`
+
+### Mail Exchanger (MX)
+
+You must set MX records on your domain. If you're using your domain for email,
+use the correct DKIM records supplied by your email provider (AWS SES,
+SendGrid, etc).
+
+If your domain does not accept email, you must set a [NULL MX Resource Record]
+(https://datatracker.ietf.org/doc/rfc7505/), such
+as:
+
+| Name/host/alias | Time to live | Record type | Priority | Value |
+|-|-|-|-|-|
+| `.` (full stop) | 3600 | MX | 0 | ` `&nbsp;(empty) |
+
+### DomainKeys Identified Mail (DKIM)
+
+You must set a DKIM record on your domain. If you're using your domain for
+email, use the correct DKIM records supplied by your email provider (AWS SES,
+SendGrid, etc).
+
+If your domain does not accept email, you must set a nullified wildcard DKIM
+record. This will ensure any cached keys will be explicitly removed.
+
+For example, on the domain: `*._domainkey.mydomain.gov.uk`, you'd set a TXT
+record to:
+
+`v=DKIM1; p=`
+
+## Mandatory HTTPS, SSL and TLS configuration for domains
+
+Your domains must always:
+
+- Have a valid TLS certificate
+- 301 (Permanently Moved) redirect unencrypted HTTP requests to HTTPS
+- Use [HTTP Strict Transport Security (HSTS)]
+  (https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html)
+  to force all connections to use HTTPS
+- Utilise [`upgrade-insecure-requests` in your Content Security Policy (CSP)]
+  (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests)
+  to force all content on a service to be loaded over HTTPS
+
+Your service must always actively:
+
+- turn off TLS insecure renegotiation
+- turn off TLS insecure protocol downgrade
+- turn off TLS record compression
+- turn off export key generation
+- turn off support for SSL 2
+
+### SSL and TLS configuration
+
+You **must not** use the deprecated SSL protocol. You **must** use the TLS
+protocol.
+
+| Protocol and version | Status |
+|-|-|
+| TLS 1.3 | Latest |
+| TLS 1.2 | Long-term support |
+| TLS 1.1 | Deprecated in 2021 ([RFC 8896](https://datatracker.ietf.org/doc/rfc8996/)), [deprecated by Apple, Google, Microsoft, Mozilla in 2020](https://arstechnica.com/gadgets/2018/10/browser-vendors-unite-to-end-support-for-20-year-old-tls-1-0/) |
+| TLS 1.0 | Deprecated in 2021 ([RFC 8896](https://datatracker.ietf.org/doc/rfc8996/)), [deprecated by Apple, Google, Microsoft, Mozilla in 2020](https://arstechnica.com/gadgets/2018/10/browser-vendors-unite-to-end-support-for-20-year-old-tls-1-0/) |
+| SSLv3 | Deprecated in 2015 ([RFC 7568](https://datatracker.ietf.org/doc/html/rfc7568)) |
+| SSLv2 | Deprecated in 2011 ([RFC 6176](https://datatracker.ietf.org/doc/html/rfc6176)) |

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -50,6 +50,7 @@ This guide is designed for developers, power users, and all team members at the 
 #### DNS and Domain Management
 
 * [DNS Managment](documentation/services/domainmgt.html)
+* [How to get, register or manage a domain name](documentation/services/how-to-get-a-domain-name.html)
 * [Domain Naming Standard](documentation/services/domain-naming-standard.html)
 * [SSL Certificate Management](documentation/services/sslcertmanage.html)
 


### PR DESCRIPTION
## 👀 Purpose

- This PR adds "How to get, register or manage a domain name" to our user guide. We are no longer going to be the owners of the Technical Guidance so we want to ensure guidance and standards that are relevant to our services are moved to our guide. This also co-locates guidance that we will also be looking the transition at a later date. Documentation in one place will make this easier.

## ♻️ What's changed

- Add "How to get, register or manage a domain name"
- Update index
- Update links in existing guidance