### PR TITLE
Relocate GitHub related guidance from Technical Guide to Ops Eng User Guide

### DIFF
--- a/source/documentation/information/licencing-software-or-code.html.md.erb
+++ b/source/documentation/information/licencing-software-or-code.html.md.erb
@@ -1,0 +1,62 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Licensing software or code
+last_reviewed_on: 2024-11-28
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+Everything we produce or use, whether open or closed, should have an
+appropriate licence applied (as [indicated by the service
+manual][service manual licencing]). Without a licence, others (even
+within the MOJ) have no way of knowing for sure if they can use it, or
+how.
+
+At the MOJ, we use the [MIT License](https://choosealicense.com/licenses/mit/).
+
+[service manual licencing]: https://www.gov.uk/service-manual/technology/making-source-code-open-and-reusable#licensing-your-code
+
+## Applying the MIT License to our work
+
+### Each repository should include a licence file
+
+This should be called `LICENCE` or `LICENCE.md`.
+
+"License" is the U.S. English spelling. We prefer the use of "Licence", which is the U.K. English spelling, however either is acceptable. GitHub will still show licence details for the British English spelling.
+
+Make sure the license content is included in full, including the title
+"The MIT License", so that readers are quickly able to see what licence
+is being used.
+
+### Use the correct copyright notice
+
+The Copyright is Crown Copyright; you can put "Ministry of Justice" in
+brackets. For example:
+
+```
+Copyright (c) 2017 Crown Copyright (Ministry of Justice)
+```
+
+The year should be the year the code was first published. Where the
+code is continually updated with significant changes, the year can be
+shown as a period from first to most recent update (e.g. 2015-2017).
+
+### Example
+
+This is an [example of our licence](https://github.com/ministryofjustice/template-repository/blob/main/LICENSE).
+
+## Reusing or incorporating others' work
+
+If a repository or package you want to reuse or build on doesn't have a
+licence, we can't be sure we legally have the right to use it in the
+way we want.
+
+When adapting an existing project, or incorporating code from one, you
+should provide proper attribution to the source in your licence.
+There's a good [guide to proper copyright and licence
+attribution](https://make.wordpress.org/themes/2014/07/08/proper-copyrightlicense-attribution-for-themes/)
+from the WordPress Theme Review Team.
+
+[This repository's licence file](https://github.com/ministryofjustice/technical-guidance/blob/main/LICENSE)
+is a good example of how to attribute incorporated works' licences.

--- a/source/documentation/information/storing-source-code.html.md.erb
+++ b/source/documentation/information/storing-source-code.html.md.erb
@@ -24,7 +24,7 @@ New repositories for products and services live in the
 [ministryofjustice organisation](https://github.com/ministryofjustice)
 on GitHub.
 
-Repositories should be [clearly named](naming-things.html)
+Repositories should be [clearly named](https://technical-guidance.service.justice.gov.uk/documentation/standards/naming-things.html)
 and have an [appropriate licence](licencing-software-or-code.html)
 and enough documentation that someone new can get started with the
 project.

--- a/source/documentation/information/storing-source-code.html.md.erb
+++ b/source/documentation/information/storing-source-code.html.md.erb
@@ -1,0 +1,105 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Storing source code
+last_reviewed_on: 2024-11-28
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+All our source code is open by default, and stored on well-known,
+public code hosting services. At the MOJ, we use GitHub.
+
+We follow the principles set out in the service manual for managing the
+code that we write:
+
+- [use version control](https://www.gov.uk/service-manual/technology/maintaining-version-control-in-coding)
+- [make source code open](https://www.gov.uk/service-manual/technology/making-source-code-open-and-reusable)
+
+You should keep secrets separate from source code, and keep them private.
+
+## GitHub
+
+New repositories for products and services live in the
+[ministryofjustice organisation](https://github.com/ministryofjustice)
+on GitHub.
+
+Repositories should be [clearly named](naming-things.html)
+and have an [appropriate licence](licencing-software-or-code.html)
+and enough documentation that someone new can get started with the
+project.
+
+Creating a new project from this [template repository] will add the
+correct licence file, as well as adding our organisation default
+`.gitignore` file and [github actions].
+
+If your repository contains secrets rather than code, make it private
+and restrict the people who have access to it. Discuss with the
+security engineering team whether you should encrypt the contents of
+the repository.
+
+### Private repositories
+
+By default, any [ministryofjustice organisation](https://github.com/ministryofjustice) member has no additional privileges. This means they can clone and pull public and internal repos only. Internal repos are essentially org-public, and anyone in the organisation can interact with them. Unless explicitly and strictly defined on a per-repository basis to override default permissions: private repositories should be considered "private" to your team/project.
+
+Delivery teams are responsible for setting correct permissions on their repos.
+This includes ensuring the right users have access, and removing privileges when
+they leave the team. It's often helpful to manage permissions across all of a
+delivery team's GitHub repositories in one place, by setting up a GitHub team
+for the people on a delivery team, and giving that GitHub team read/write
+privileges for the repos.
+
+### Converting private or internal repositories to public
+
+If you are in a position to make source code open to the public after it was kept private for a while, you need to make sure there is no sensitive data in the commit history. This does not apply just to the current state of the main branch, but to all commits in the history of the repository. A good place to start is by going to the Security tab in the repository and checking for any secrets that may have been committed at any point.
+
+If you do find sensitive information has been committed, you need to cycle it out of use and then [scrub your git history](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository) to remove it. It is very important that you cycle the credentials, because even after scrubbing, they will still be present in any cached and local copies and will still be vulnerable.
+
+In case any user information has been committed, you need to talk to the security and data privacy teams before proceeding.
+
+### GitHub access
+
+#### Your account
+
+If you already have a GitHub account from before you joined MOJ, you can choose to use it at MOJ or create a new one. Some people prefer to have continuity with previous work; others value the separation.
+
+You must [add your MOJ email address to your
+account](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/adding-an-email-address-to-your-github-account).
+It needs to be the 'primary email' address on the account to enable SSO onto other developer related tooling.
+You may want to [use that email for notifications](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#choosing-where-your-organizations-email-notifications-are-sent).
+
+In preparation for when you leave MoJ, it's suggested you add a home email
+address to your account as the 'backup email'. The reason is that the account is
+yours, not MoJ's, so it remains your responsibility. When you leave you should
+actively close or keep control of the account. Whilst you won't retain MOJ repo
+permissions, you may have to relinquish other access you've gained in the course
+of your work (for example cross-government work) - check your user settings for Organizations, Repos and
+Applications. And it might be prudent to retain the ability to change your
+account's public profile or delete public comments. Home email addresses are not
+exposed to GitHub organisation admins, aside from what is already public.
+
+You don't have to use your real name or photo - just let your colleagues know
+your username.
+
+#### Member of the MoJ organisation
+
+Being a **member** of the MoJ organisation is for staff who are permanent employees or contractors working directly with the MoJ.
+To be added to the `ministryofjustice` organisation, first ensure you've enabled two-factor authentication.
+If you have a `@digital.justice.gov.uk` or `@justice.gov.uk` email address and only require access to the `ministryofjustice` Organisation, you can simply join via [SSO](https://github.com/orgs/ministryofjustice/sso).
+For more information, please refer to the [Operations Engineering user guide](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojgithubenterprise.html).
+
+#### Outside Collaborator
+
+Being an **outside collaborator** is for third party suppliers who are maintaining code on behalf of the MoJ.
+
+Outside collaborators can only access specific repositories and are limited in what they can do within the MoJ organisation. They are not able to access private repositories outside of the ones they've been assigned to. They do not have access to the Cloud Platform cluster. Collaborators cannot be added to GitHub teams.
+
+Users do not require an MoJ email address to be added as outside collaborators.
+
+You can add outside collaborators via the [github-collaborators] repository.
+
+The operations-engineering team track Outside Collaborators on the MoJ GitHub Organisation via the [github-collaborators] repository.
+
+[template repository]: https://github.com/ministryofjustice/template-repository
+[github actions]: https://github.com/ministryofjustice/github-actions
+[github-collaborators]: https://github.com/ministryofjustice/github-collaborators

--- a/source/documentation/information/using-git.html.md.erb
+++ b/source/documentation/information/using-git.html.md.erb
@@ -1,0 +1,109 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Using Git
+last_reviewed_on: 2024-11-28
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+## Overview
+
+[git][git] is a [distributed version-control system][dvcs]. It's distributed,
+in that there's no central source of truth. Each copy of a repository can
+contain the entire history, and be considered an authoritative source. But we
+tend to use it in a centralised fashion, treating the version that is
+[hosted on GitHub](https://github.com/ministryofjustice) as the shared central
+version, and basing all work against that copy.
+
+It has excellent tools for branching and merging. Branching is possible in
+other version control systems, but merging can be very painful. This made
+people tentative about using that workflow.
+
+In git, that problem goes away.
+
+## Tutorials
+
+* [GitHub Hello World](https://docs.github.com/en/get-started/quickstart/hello-world)
+* [https://www.atlassian.com/git/tutorials](https://www.atlassian.com/git/tutorials)
+
+## How-to
+
+### Set up to start contributing
+
+Do not fork – [clone a repo](https://www.git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository#_git_cloning) from
+[https://github.com/ministryofjustice](https://github.com/ministryofjustice)
+to your local machine.
+
+### Work locally
+
+[Create a branch](https://www.git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging#_basic_branching) to work in for your changes.
+
+Before you create a branch, it's worth considering the branch names and how you
+think the branch might become visible to other people.
+
+A common prefix can be useful for categorising branches, and working with tools
+for continuous integration. Naming branches such as `feature/foo`,
+`feature/bar`, and `bug/fix-column-migration` can help other people in the team
+understand whether it's a feature (new behaviour) or a fixing a bug. Having a
+common prefix can also work well with continuous integration tools such as
+[Travis][travis], which might be
+[instructed to only do certain actions on branches](https://docs.travis-ci.com/user/customizing-the-build#using-regular-expressions)
+named `feature/*` versus the `main` branch.
+
+Other approaches:
+
+* `feature/{JIRA-issue}-{description}` – this change is for the Jira issue
+  LM-6, and also has a human-readable description to give people more context.
+  Also, one or more people might be working on this branch (pairing, or
+  separately)
+* `jabley/thing` – this branch contains work that developer known as jabley is
+  doing. Other people might not want to rely on this branch, since it might be
+  force-pushed (but nicely please!)
+
+### Commit locally regularly
+
+This can help to get to the point where you have a working version, and then
+want to try adding a new thing. Try to aim for each [commit](https://www.git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository)
+to be an atomic unit that delivers a non-broken version of the code-base. As
+you make more changes, consider whether it should be separate commit, or an
+amendment to the last one. You can always
+[interactively rebase your changes](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
+to edit the commit history to a logical changeset.
+
+### Push your changes regularly
+
+This protects you from local hardware failure, and
+[ensures you don't lose your changes](https://www.git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes#_pushing_remotes).
+
+### Request a review
+
+Once you have got to the point where you consider the change complete, you
+should [open a pull request on GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request),
+asking for the changes to be reviewed by someone else on the team.
+
+### Review pull requests
+
+Before commenting on a pull request, ensure you know how the person would
+prefer to get feedback. This might involve asking them first. Feedback options
+include face-to-face, pairing, via email/Slack, or commenting on a pull request.
+
+Ideally, continuous integration should be set up to provide some feedback on a
+pull request (the tests pass, coding style has been followed etc). If not,
+you'll probably want to pull the code and try it out for yourself.
+
+## Further Reading
+
+* [Anna Shipman][anna]'s description of [how to create good pull requests](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
+* [Alice Bartlett][alice] wrote
+  [a very honest account of her experience moving to coding in the open and using GitHub](https://alicebartlett.co.uk/blog/six-months-at-gds). She also did
+  [a nice talk introducing Git for non-technical folk](https://www.youtube.com/watch?v=eWxxfttcMts)
+* [Why we care about commit messages](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages).
+  Commit messages live longer than pull requests
+* [The GOV.UK pull request process has some GitHub-specific advice](https://gds-way.cloudapps.digital/standards/pull-requests.html)
+
+[alice]:    https://twitter.com/alicebartlett
+[anna]:     https://twitter.com/annashipman
+[dvcs]:     https://en.wikipedia.org/wiki/Distributed_version_control
+[git]:      https://git-scm.com/
+[travis]:   https://travis-ci.org/

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -32,12 +32,15 @@ This guide is designed for developers, power users, and all team members at the 
 #### GitHub
 
 * [Management](documentation/information/mojgithubenterprise.html)
+* [Storing source code](documentation/information/storing-source-code.html)
+* [Using Git](documentation/information/using-git.html)
 * [Community Slack Channel](documentation/information/githubcommunity.html)
 * [Feature Requests](documentation/information/githubfeature.html)
 * [How to Create Organisation-Level Fine-Grained Tokens] (documentation/information/Guidance-on-creating-PAT-Tokens.html)
 * [Repository Standards](documentation/information/mojrepostandards.html)
 * [Add a Compliance Badge To Your README](documentation/information/add-repo-badge.html)
 * [Tips on Managing Notifications](documentation/information/managing-github-notifications.html)
+* [Licensing software or code](documentation/information/licencing-software-or-code.html)
 * [Advice: Store Code Privately](documentation/information/storing-code-in-private.html)
 * [Advice: Store Code Publicly](documentation/information/storing-code-in-public.html)
 


### PR DESCRIPTION
## 👀 Purpose

- This PR relocates GitHub related guidance from the Technical Guide to the Operations Engineering User Guide. This is part of the work to remove Ops Eng ownership of the Technical Guide.

## ♻️ What's changed

- Adds Storing Source Code 
- Adds using Git
- Adds Licensing software or code
- Updates index