### PR TITLE
Update GitHub Guidance Links

### DIFF
--- a/source/documentation/information/mojgithubenterprise.html.md.erb
+++ b/source/documentation/information/mojgithubenterprise.html.md.erb
@@ -36,7 +36,7 @@ limits means that the service will be unavailable for private and internal repos
 _**These limits do not apply to public repositories.**_
 
 If you are considering making your repository public, consider reading the technical guidance
-on [converting private or internal repositories to public](https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#private-repositories)
+on [converting private or internal repositories to public](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#private-repositories)
 and
 our [Dos and Don't Guide for Public Repositories](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-code-in-public.html).
 
@@ -62,7 +62,7 @@ at [Operations Engineering](mailto:operations-engineering@digital.justice.gov.uk
 
 If you are a Third-Party Supplier who is maintaining code on behalf of the Ministry of Justice, you will need to be
 added as
-an [Outside Collaborator](https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#outside-collaborator).
+an [Outside Collaborator](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#outside-collaborator).
 
 Outside Collaborators will only be able to gain access to specific repositories.
 
@@ -70,7 +70,7 @@ Outside Collaborators will only be able to gain access to specific repositories.
 
 When a user joins one of our Github Organisations as a member they are added to the `all-org-members` or `everyone` Team, in the case of the Ministry of Justice or MoJ Analytical Services Organisation respectively. Addition to these teams enables access to a number of MoJ shared tools and platforms.
 
-To enable users to make changes to code and work with a repository, they must be added to the repository with the appropriate permissions, either with direct access or via a Github Team. In accordance with the [Technical Standards](https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#github):
+To enable users to make changes to code and work with a repository, they must be added to the repository with the appropriate permissions, either with direct access or via a Github Team. In accordance with the [Technical Standards](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#github):
 
 > Delivery teams are responsible for setting correct permissions on their repos. This includes ensuring the right users have access and removing privileges when they leave the team. It’s often helpful to manage permissions across all of a delivery team’s GitHub repositories in one place, by setting up a GitHub team for the people on a delivery team, and giving that GitHub team read/write privileges for the repos.
 

--- a/source/documentation/information/mojrepostandards.html.md.erb
+++ b/source/documentation/information/mojrepostandards.html.md.erb
@@ -27,7 +27,7 @@ Our GitHub repository standards have specific criteria that a repository must me
 
 We maintain a [reports-dashboard](https://github.com/ministryofjustice/operations-engineering-reports) to identify commonalities and trends across the organisation and identify improvement areas. The Operations Engineering team uses this information to guide and support teams and projects and ensure that our GitHub repositories remain accessible, safe, and easy to contribute to.
 
-To read more about why we have these standards, please see our [technical standards documentation](https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#storing-source-code).
+To read more about why we have these standards, please see our [technical standards documentation](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#storing-source-code).
 
 ## How to apply the standards
 

--- a/source/documentation/information/storing-code-in-private.html.md.erb
+++ b/source/documentation/information/storing-code-in-private.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Storing Code in Private Repositories
-last_reviewed_on: 2024-11-28
+last_reviewed_on: 2024-12-09
 review_in: 3 months
 ---
 
@@ -105,7 +105,7 @@ Some other considerations:
 - Ensure all stakeholders are aligned on the decision to move from private/internal to public.
 - As the repository will become part of MoJ's public domain, you may need to re-evaluate its standards compliance.
 
-More information can be found in [this guide](https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html).
+More information can be found in [this guide](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#storing-source-code).
 
 ### References
 
@@ -115,13 +115,13 @@ More information can be found in [this guide](https://technical-guidance.service
 * [Technology Code of Practice (TCoP)](https://www.gov.uk/guidance/the-technology-code-of-practice#be-open-and-use-open-source)
 * [GitHub Guidelines for ministryofjustice](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojgithubenterprise.html)
 * [Managing software dependiencies](https://www.gov.uk/service-manual/technology/managing-software-dependencies)
-* [Storing source code](https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html)
+* [Storing source code](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#storing-source-code)
 * [Documenting how your service is supported](https://technical-guidance.service.justice.gov.uk/documentation/standards/documenting-how-your-service-is-supported.html)
 
 [be and use open by default]: https://www.gov.uk/guidance/government-design-principles#be-open-by-default
 [security considerations for open source software]: https://www.gov.uk/government/publications/open-source-guidance/security-considerations-when-coding-in-the-open
 [when code should be open]: https://www.gov.uk/government/publications/open-source-guidance/when-code-should-be-open-or-closed
-[secrets in code]: https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#storing-source-code
+[secrets in code]: https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#storing-source-code
 [documenting your code]: https://technical-guidance.service.justice.gov.uk/documentation/standards/documenting-how-your-service-is-supported.html
 [development principles]: https://technical-guidance.service.justice.gov.uk/documentation/principles/development-principles.html
-[private repositories]: https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#private-repositories
+[private repositories]: https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#private-repositories

--- a/source/documentation/information/storing-code-in-public.html.md.erb
+++ b/source/documentation/information/storing-code-in-public.html.md.erb
@@ -100,14 +100,14 @@ Always consult with the security team and follow best practices for handling sen
 - [Technology Code of Practice (TCoP)](https://www.gov.uk/guidance/the-technology-code-of-practice#be-open-and-use-open-source)
 - [GitHub Guidelines for ministryofjustice](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojgithubenterprise.html)
 - [Managing software dependiencies](https://www.gov.uk/service-manual/technology/managing-software-dependencies)
-- [Storing source code](https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html)
+- [Storing source code](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#storing-source-code)
 - [Documenting how your service is supported](https://technical-guidance.service.justice.gov.uk/documentation/standards/documenting-how-your-service-is-supported.html)
 
 [be and use open by default]: https://www.gov.uk/guidance/government-design-principles#be-open-by-default
 [security considerations for open source software]: https://www.gov.uk/government/publications/open-source-guidance/security-considerations-when-coding-in-the-open
 [when code should be open]: https://www.gov.uk/government/publications/open-source-guidance/when-code-should-be-open-or-closed
-[secrets in code]: https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#storing-source-code
-[dealing with sensitive leaks]: https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#converting-private-or-internal-repositories-to-public
+[secrets in code]: https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#storing-source-code
+[dealing with sensitive leaks]: https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#converting-private-or-internal-repositories-to-public
 [documenting your code]: https://technical-guidance.service.justice.gov.uk/documentation/standards/documenting-how-your-service-is-supported.html
 [development principles]: https://technical-guidance.service.justice.gov.uk/documentation/principles/development-principles.html
-[private repositories]: https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#private-repositories
+[private repositories]: https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#private-repositories


### PR DESCRIPTION
This PR updates links to guidance that has recently moved to the Operations Engineering User Guide