### PR TITLE
Remove Trello URL

### DIFF
--- a/source/documentation/services/domain-naming-standard.html.md.erb
+++ b/source/documentation/services/domain-naming-standard.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Domain Naming Standard
-last_reviewed_on: 2025-03-06
+last_reviewed_on: 2025-05-20
 review_in: 3 months
 ---
 
@@ -39,8 +39,7 @@ This includes:
 
 However, cloud-hosted software-as-a-service used by MOJ staff (like Google
 Workspace or Microsoft365), or on which MOJ has a corporate presence (like
-[GitHub](https://github.com/ministryofjustice) or [Trello]
-(<https://trello.com/mojds/home>)) are not required to be served from a
+[GitHub](https://github.com/ministryofjustice) or Trello) are not required to be served from a
 `*.service.justice.gov.uk` subdomain.
 
 #### Cloud Platform and Modernisation Platform


### PR DESCRIPTION
This PR removes a Trello URL. Guide doesn't benefit from a link to the MoJ account. This also fixes a failing link check does to destination behind authentication.